### PR TITLE
Adding a listing for "The Ghost Map: The Story of London's Most Terrifying Epidemic--and How It Changed Science, Cities, and the Modern World"

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,7 +62,7 @@ The [GitHub Pages version](https://karpet.github.io/gov-tech-reading-list/) of t
 * [The Responsive City: Engaging Communities Through Data-Smart Governance](https://www.indiebound.org/book/9781118910900) by Stephen Goldsmith and Susan Crawford
 * [Power to the Public](https://www.indiebound.org/book/9780691207759) by Tara Dawson McGuinness and Hana Schank
 * [Democracy Reinvented](https://www.indiebound.org/book/9780815726821) by Hollie Russon Gilman
-
+* [The Ghost Map](https://bookshop.org/p/books/the-ghost-map-with-earbuds-steven-johnson/15546357?ean=9781594482694) by Steven Johnson
 
 ## Articles
 


### PR DESCRIPTION
This book is essential reading for anyone that cares about cities, urban infrastructure and engineering, cartography, open data, and civic hacking. Published in 2007, it landed just as open data was starting to take hold in cities across the country and new tools for developing maps based on this data were becoming readily available. And it accurately predicted the way that these new tools would change cities.

It tells the story of John Snow and his efforts to identify the source of a vicious Cholera outbreak in mid-19th Century London. Snow can be considered, in my opinion, the first civic hacker. A doctor by trade, he conducted his own surveys and data collection tactics to develop innovative visualizations that provided different ways of looking at the outbreak. He used this data and his new maps to correctly point to the source of the Cholera outbreak - the water supply - and forever after influenced data science and urban infrastructure.

Excited to add this to your list.